### PR TITLE
Feature/account 로그인 파트 구현

### DIFF
--- a/src/main/java/com/stocking/modules/account/Account.java
+++ b/src/main/java/com/stocking/modules/account/Account.java
@@ -1,5 +1,6 @@
 package com.stocking.modules.account;
 
+import com.stocking.modules.account.Role;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/stocking/modules/account/AccountController.java
+++ b/src/main/java/com/stocking/modules/account/AccountController.java
@@ -1,5 +1,7 @@
 package com.stocking.modules.account;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +14,16 @@ import javax.validation.Valid;
 @RequestMapping(value = "/api/account")
 @RestController
 @RequiredArgsConstructor
+@Api(value = "AccountController", tags = "로그인")
 public class AccountController {
 
     private final AccountService accountService;
+
+    @ApiOperation(value = "최대 상승 주식 목록 조회")
+    @GetMapping("/signup/best-stocks")
+    public ResponseEntity<Object> getBestStocks() {
+        return new ResponseEntity<>(accountService.getBestStocks(), HttpStatus.OK);
+    }
 
     @GetMapping("/login")
     public ResponseEntity<Object> login(Long uuid, Error error) {

--- a/src/main/java/com/stocking/modules/account/AccountService.java
+++ b/src/main/java/com/stocking/modules/account/AccountService.java
@@ -1,22 +1,45 @@
 package com.stocking.modules.account;
 
-import com.stocking.modules.buythen.repo.StocksPriceRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stocking.modules.buythen.repo.QStocksPrice;
+import com.stocking.modules.stock.QStock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
     private final AccountRepository accountRepository;
-    private final StocksPriceRepository stocksPriceRepository;
+
+    private final JPAQueryFactory queryFactory;
 
     List<String> getBestStocks() {
-        List<String> list = null;
-        return list;
+
+        QStocksPrice qStocksPrice = QStocksPrice.stocksPrice;
+        QStock qStock = QStock.stock;
+
+        List<Long> bestStockIdList = queryFactory.select(qStocksPrice.stocksId)
+                .from(qStocksPrice)
+                .where(qStocksPrice.marketCap.isNotNull())
+                .orderBy(qStocksPrice.marketCap.desc())
+                .limit(9)
+                .fetch();
+
+        List<String> bestStockNameList = bestStockIdList.stream()
+                .map(vo -> {
+                    String company = queryFactory.select(qStock.company)
+                            .from(qStock)
+                            .where(qStock.id.eq(vo))
+                            .fetchOne();
+                    return company;
+                }).collect(Collectors.toList());
+
+        return bestStockNameList;
     }
 
     public void saveNewAccount(SignUpForm signUpForm) {

--- a/src/main/java/com/stocking/modules/account/AccountService.java
+++ b/src/main/java/com/stocking/modules/account/AccountService.java
@@ -1,14 +1,23 @@
 package com.stocking.modules.account;
 
+import com.stocking.modules.buythen.repo.StocksPriceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
     private final AccountRepository accountRepository;
+    private final StocksPriceRepository stocksPriceRepository;
+
+    List<String> getBestStocks() {
+        List<String> list = null;
+        return list;
+    }
 
     public void saveNewAccount(SignUpForm signUpForm) {
 


### PR DESCRIPTION
# 상위 시총 9개 종목 반환 API 구현

## PR 설명
- 로그인 과정에서 상위 시총 9개 종목 리스트를 반환하는 API 구현

## 추가적인 정보
- 종목 조회 쿼리 최적화 생각해보기
