### PR TITLE
feat: 오늘의 단어 기능 추가

### DIFF
--- a/src/main/java/com/stocking/modules/todayword/vo/TodayWordOrder.java
+++ b/src/main/java/com/stocking/modules/todayword/vo/TodayWordOrder.java
@@ -1,5 +1,5 @@
 package com.stocking.modules.todayword.vo;
 
 public enum TodayWordOrder {
-    LATELY, POPULARITY;
+    LATELY, POPULARITY, WEEKLY_POPULARITY;
 }


### PR DESCRIPTION
## #18 

## PR 설명
- 오늘의 단어 목록 조회 기능

## 변경된 내용
- 오늘의 단어 조회의 일주일간 좋아요 가장 많은 순으로 정렬하는 기능 추가
- 오늘의 단어 조회 이전 정렬 기준에 좋아요 수가 같을 때 단어 사전순으로 정렬하도록 추가
