### PR TITLE
Feature/buythen 그때 살걸 예외케이스 처리(기간값, 금액값)

### DIFF
--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -181,6 +181,7 @@ public class BuyThenService {
         Boolean isPriceException = Boolean.FALSE;
         if (oldStockPrice.get().compareTo(investPrice) < 0) {
             newInvestPrice = oldStockPrice.get();
+            isExceptionCase = Boolean.TRUE;
             isPriceException = Boolean.TRUE;
         }
 

--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -179,7 +179,7 @@ public class BuyThenService {
         // 금액값 예외 확인
         BigDecimal newInvestPrice = investPrice;
         Boolean isPriceException = Boolean.FALSE;
-        if (oldStockPrice.get().compareTo(investPrice) < 0) {
+        if (oldStockPrice.get().compareTo(investPrice) > 0) {
             newInvestPrice = oldStockPrice.get();
             isExceptionCase = Boolean.TRUE;
             isPriceException = Boolean.TRUE;
@@ -249,7 +249,7 @@ public class BuyThenService {
             .lastTradingDateTime(lastTradeTime)
             .calculatedValue(
                 CalculatedValue.builder()
-                    .investPrice(investPrice)
+                    .investPrice(newInvestPrice)
                     .investDate(newInvestDate.getName())
                     .oldPrice(oldStockPrice.get())
                     .yieldPrice(yieldPrice)

--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -43,6 +44,7 @@ import com.stocking.infra.common.StockUtils.StockHist;
 import com.stocking.modules.buyornot.repo.EvaluateBuySell.BuySell;
 import com.stocking.modules.buythen.CalcHistRes.CalculationHist;
 import com.stocking.modules.buythen.CalculatedRes.CalculatedValue;
+import com.stocking.modules.buythen.CalculatedRes.ExceptionCase;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.CurrentValue;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.IndustryValue;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.KospiValue;
@@ -57,6 +59,8 @@ import com.stocking.modules.stock.Stock;
 import com.stocking.modules.stock.StockRepository;
 
 import lombok.extern.slf4j.Slf4j;
+
+import static com.stocking.modules.buythen.InvestDate.DAY1;
 
 @Service
 @Slf4j
@@ -121,24 +125,46 @@ public class BuyThenService {
         StocksPrice stockPrice = stocksPriceRepository.findByStocksId(stock.getId())
                 .orElseThrow(() -> new Exception("종목코드가 올바르지 않습니다."));
         
-        String code = stock.getCode();
-        InvestDate investDate = buyThenForm.getInvestDate();
-        BigDecimal investPrice = buyThenForm.getInvestPrice();    // 투자금
+        String code = stock.getCode();                          // 종목 코드
+        InvestDate investDate = buyThenForm.getInvestDate();    // 투자 날짜
+        BigDecimal investPrice = buyThenForm.getInvestPrice();  // 투자금
+
+        Boolean isExceptionCase = Boolean.FALSE;                // 예외 케이스 여부
 
         // 과거 주가
-        BigDecimal oldStockPrice = Optional.ofNullable( switch (investDate) {
-            case DAY1 -> stockPrice.getPrice();
-            case WEEK1 -> stockPrice.getPriceW1();
-            case MONTH1 -> stockPrice.getPriceM1();
-            case MONTH6 -> stockPrice.getPriceM6();
-            case YEAR1 -> stockPrice.getPriceY1();
-            case YEAR5 -> stockPrice.getPriceY5();
-            case YEAR10 -> stockPrice.getPriceY10();
-            default -> throw new IllegalArgumentException("Unexpected value: " + investDate);
-        }).orElseThrow(() -> new Exception(stock.getCompany() + " 는(은) " + investDate.getName() + " 데이터가 없습니다."));
+        List<InvestDate> investDates = new ArrayList<InvestDate>(EnumSet.allOf(InvestDate.class));
+        int investDateIndex = investDates.indexOf(investDate);
+        InvestDate newInvestDate = investDate;
+        Boolean isDateExceptionCase = Boolean.FALSE;
+
+        Optional<BigDecimal> oldStockPrice = Optional.empty();
+        for (int i=investDateIndex-1;i>=0;i--) {
+            oldStockPrice = Optional.ofNullable( switch (newInvestDate) {
+                case DAY1 -> stockPrice.getPrice();
+                case WEEK1 -> stockPrice.getPriceW1();
+                case MONTH1 -> stockPrice.getPriceM1();
+                case MONTH6 -> stockPrice.getPriceM6();
+                case YEAR1 -> stockPrice.getPriceY1();
+                case YEAR5 -> stockPrice.getPriceY5();
+                case YEAR10 -> stockPrice.getPriceY10();
+                default -> throw new IllegalArgumentException("Unexpected value: " + newInvestDate);
+            });
+
+            if (oldStockPrice.isPresent()) {
+                break;
+            }
+            newInvestDate = investDates.get(i);
+            isDateExceptionCase = Boolean.TRUE;
+            isExceptionCase = Boolean.TRUE;
+        }
+        if (!oldStockPrice.isPresent()) {
+            throw new Exception(
+                    stock.getCompany() + " 의 주식 데이터가 존재하지 않습니다."
+            );
+        }
         
         // 종가일자
-        LocalDateTime oldCloseDate = switch (investDate) {    
+        LocalDateTime oldCloseDate = switch (newInvestDate) {
             case DAY1 -> stockPrice.getLastTradeDate();
             case WEEK1 -> stockPrice.getDateW1();
             case MONTH1 -> stockPrice.getDateM1();
@@ -149,19 +175,31 @@ public class BuyThenService {
             default -> throw new IllegalArgumentException("Unexpected value: " + investDate);
         };
 
+
+        // 금액값 예외 확인
+        BigDecimal newInvestPrice = investPrice;
+        Boolean isPriceException = Boolean.FALSE;
+        if (oldStockPrice.get().compareTo(investPrice) < 0) {
+            newInvestPrice = oldStockPrice.get();
+            isPriceException = Boolean.TRUE;
+        }
+
+        // 상승률 계산
         RealTimeStock realTimeStock = stockUtils.getStockInfo(code);
-        
+
         BigDecimal currentPrice = realTimeStock.getCurrentPrice(); // 현재가 - 실시간정보 호출
         String lastTradeTime = realTimeStock.getLastTradeTime();
-        
-        BigDecimal holdingStock = investPrice.divide(oldStockPrice, MathContext.DECIMAL32);     // 내가 산 주식 개수 
-        BigDecimal yieldPercent = currentPrice.subtract(oldStockPrice).divide(oldStockPrice, MathContext.DECIMAL32).multiply(new BigDecimal(100));  // (현재가-이전종가)/이전종가 * 100
-        BigDecimal yieldPrice = investPrice.add(investPrice.multiply(yieldPercent).divide(new BigDecimal(100)));  // 수익금 = 투자금 + (투자금*수익률*100)
 
+        BigDecimal holdingStock = newInvestPrice.divide(oldStockPrice.get(), MathContext.DECIMAL32);     // 내가 산 주식 개수
+        BigDecimal yieldPercent = currentPrice.subtract(oldStockPrice.get()).divide(oldStockPrice.get(), MathContext.DECIMAL32).multiply(new BigDecimal(100));  // (현재가-이전종가)/이전종가 * 100
+        BigDecimal yieldPrice = newInvestPrice.add(newInvestPrice.multiply(yieldPercent).divide(new BigDecimal(100)));  // 수익금 = 투자금 + (투자금*수익률*100)
+
+
+        // 연봉, 월급 계산
         BigDecimal salaryYear = null;      // 연봉
         BigDecimal salaryMonth = null;     // 월급
         
-        switch (investDate) {
+        switch (newInvestDate) {
             case DAY1, WEEK1, MONTH1 :
                 salaryYear = yieldPrice;
                 salaryMonth = yieldPrice;
@@ -184,6 +222,7 @@ public class BuyThenService {
                 break;
             default : throw new IllegalArgumentException("Unexpected value: " + investDate);
         }
+
         
         // 계산이력 저장
         calcHistRepository.save(
@@ -192,8 +231,8 @@ public class BuyThenService {
     			.company(stockPrice.getCompany())
     			.createdUid(user.getUid())
     			.investDate(oldCloseDate)
-    			.investDateName(investDate.getName())
-    			.investPrice(investPrice)
+    			.investDateName(newInvestDate.getName())
+    			.investPrice(newInvestPrice)
     			.yieldPrice(yieldPrice)
     			.yieldPercent(yieldPercent)
     			.price(currentPrice)
@@ -210,16 +249,26 @@ public class BuyThenService {
             .calculatedValue(
                 CalculatedValue.builder()
                     .investPrice(investPrice)
-                    .investDate(investDate.getName())
-                    .oldPrice(oldStockPrice)
+                    .investDate(newInvestDate.getName())
+                    .oldPrice(oldStockPrice.get())
                     .yieldPrice(yieldPrice)
                     .yieldPercent(yieldPercent)
                     .oldCloseDate(oldCloseDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
                     .holdingStock(holdingStock)
                     .salaryYear(salaryYear)
                     .salaryMonth(salaryMonth)
-                    .build()
-            ).build();
+                    .build())
+            .exceptionCase(
+                ExceptionCase.builder()
+                    .isExceptionCase(isExceptionCase)
+                    .isDateException(isDateExceptionCase)
+                    .oldInvestDate(investDate)
+                    .newInvestDate(newInvestDate)
+                    .isPriceException(isPriceException)
+                    .oldInvestPrice(investPrice)
+                    .newInvestPrice(newInvestPrice)
+                    .build())
+            .build();
         
     }
 
@@ -439,7 +488,7 @@ public class BuyThenService {
      * @return
      */
     public YieldSortRes getYieldSortList(InvestDate investDate, BuySell buySell, int pageSize, int pageNo) {
-        if(InvestDate.DAY1 == investDate) { 
+        if(DAY1 == investDate) {
             // 1일 전 수익률은 계속 바뀌는 현재가랑 재계산을 종목 갯수만큼 해야해서 보류...? 
             return YieldSortRes.builder().build();
         }

--- a/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
+++ b/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
@@ -23,6 +23,8 @@ public class CalculatedRes {
     
     @ApiModelProperty(notes = "계산 결과", required=false, position=5)
     private CalculatedValue calculatedValue;
+    @ApiModelProperty(notes = "예외 케이", required=false, position=6)
+    private ExceptionCase exceptionCase;
     
     @Data
     @AllArgsConstructor
@@ -47,5 +49,31 @@ public class CalculatedRes {
         @ApiModelProperty(notes = "월급", required=false, position=9)
         private BigDecimal salaryMonth;
     }
-    
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class ExceptionCase {
+        @ApiModelProperty(notes = "예외 케이스 여부", required=false, position=1)
+        private Boolean isExceptionCase;
+
+        @ApiModelProperty(notes = "기간값 예외 케이스 여부", required=false, position=2)
+        private Boolean isDateException;
+        @ApiModelProperty(notes = "기존 투자 날짜", required=false, position=2)
+        private InvestDate oldInvestDate;
+        @ApiModelProperty(notes = "새 투자 날짜", required=false, position=2)
+        private InvestDate newInvestDate;
+
+        @ApiModelProperty(notes = "금액값 예외 케이스 여부", required=false, position=4)
+        private Boolean isPriceException;
+        @ApiModelProperty(notes = "기존 금액값", required=false, position=5)
+        private BigDecimal oldInvestPrice;
+        @ApiModelProperty(notes = "새 금액값", required=false, position=5)
+        private BigDecimal newInvestPrice;
+
+        @ApiModelProperty(notes = "종목 예외 케이스 여부", required=false, position=6)
+        private Boolean isStockException;
+        @ApiModelProperty(notes = "종목 예외 경고 메시지", required=false, position=7)
+        private String stockWarnMsg;
+    }
 }

--- a/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
+++ b/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
@@ -23,7 +23,7 @@ public class CalculatedRes {
     
     @ApiModelProperty(notes = "계산 결과", required=false, position=5)
     private CalculatedValue calculatedValue;
-    @ApiModelProperty(notes = "예외 케이", required=false, position=6)
+    @ApiModelProperty(notes = "예외 케이스", required=false, position=6)
     private ExceptionCase exceptionCase;
     
     @Data
@@ -59,21 +59,21 @@ public class CalculatedRes {
 
         @ApiModelProperty(notes = "기간값 예외 케이스 여부", required=false, position=2)
         private Boolean isDateException;
-        @ApiModelProperty(notes = "기존 투자 날짜", required=false, position=2)
+        @ApiModelProperty(notes = "기존 투자 날짜", required=false, position=3)
         private InvestDate oldInvestDate;
-        @ApiModelProperty(notes = "새 투자 날짜", required=false, position=2)
+        @ApiModelProperty(notes = "새 투자 날짜", required=false, position=4)
         private InvestDate newInvestDate;
 
-        @ApiModelProperty(notes = "금액값 예외 케이스 여부", required=false, position=4)
+        @ApiModelProperty(notes = "금액값 예외 케이스 여부", required=false, position=5)
         private Boolean isPriceException;
-        @ApiModelProperty(notes = "기존 금액값", required=false, position=5)
+        @ApiModelProperty(notes = "기존 금액값", required=false, position=6)
         private BigDecimal oldInvestPrice;
-        @ApiModelProperty(notes = "새 금액값", required=false, position=5)
+        @ApiModelProperty(notes = "새 금액값", required=false, position=7)
         private BigDecimal newInvestPrice;
 
-        @ApiModelProperty(notes = "종목 예외 케이스 여부", required=false, position=6)
+        @ApiModelProperty(notes = "종목 예외 케이스 여부", required=false, position=8)
         private Boolean isStockException;
-        @ApiModelProperty(notes = "종목 예외 경고 메시지", required=false, position=7)
+        @ApiModelProperty(notes = "종목 예외 경고 메시지", required=false, position=9)
         private String stockWarnMsg;
     }
 }


### PR DESCRIPTION
## #13

## PR 설명
- 기간값, 금액값 예외 케이스 처리

## 변경된 내용
- 그때 살걸 계산기 api의  기간값, 금액값 예외 케이스  처리.
- 계산기에 넣은 투자날짜, 투자금이 계산 가능한 범위를 벗어났을 때, 계산 가능한 범위의 값으로 대체함.
- 경고 메시지를 띄울 수 있도록 예외 처리 여부를 응답에 포함하여 보내줌.
