### PR TITLE
[Feature/buythen] 그때 살걸 종목 예외케이스 처리 기능 추가

### DIFF
--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -138,7 +138,7 @@ public class BuyThenService {
         Boolean isDateExceptionCase = Boolean.FALSE;
 
         Optional<BigDecimal> oldStockPrice = Optional.empty();
-        for (int i=investDateIndex-1;i>=0;i--) {
+        for (int i=investDateIndex;i>=0;i--) {
             oldStockPrice = Optional.ofNullable( switch (newInvestDate) {
                 case DAY1 -> stockPrice.getPrice();
                 case WEEK1 -> stockPrice.getPriceW1();
@@ -149,7 +149,8 @@ public class BuyThenService {
                 case YEAR10 -> stockPrice.getPriceY10();
                 default -> throw new IllegalArgumentException("Unexpected value: " + newInvestDate);
             });
-
+            System.out.println("test");
+            System.out.println(oldStockPrice);
             if (oldStockPrice.isPresent()) {
                 break;
             }

--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -132,7 +132,14 @@ public class BuyThenService {
         InvestDate investDate = buyThenForm.getInvestDate();    // 투자 날짜
         BigDecimal investPrice = buyThenForm.getInvestPrice();  // 투자금
 
-        Boolean isExceptCase = Boolean.FALSE;                // 예외 케이스 여부
+        Boolean isExceptCase;                                   // 예외 케이스 여부
+
+        // 종목 예외 확인
+        Boolean isTradingHalt = stockPrice.getTradingHalt();
+        Boolean isInvestmentAlert = stockPrice.getInvestmentAlert();
+        Boolean isManagement = stockPrice.getManagement();
+        Boolean isStockExcept = isTradingHalt | isInvestmentAlert | isManagement;
+        isExceptCase = isStockExcept;
 
         // 과거 주가
         List<InvestDate> investDates = new ArrayList<InvestDate>(EnumSet.allOf(InvestDate.class));
@@ -186,6 +193,7 @@ public class BuyThenService {
             isExceptCase = Boolean.TRUE;
             isPriceExcept = Boolean.TRUE;
         }
+
         // 상승률 계산
         RealTimeStock realTimeStock = stockUtils.getStockInfo(code);
 
@@ -269,6 +277,10 @@ public class BuyThenService {
                     .isPriceExcept(isPriceExcept)
                     .oldInvestPrice(investPrice)
                     .newInvestPrice(newInvestPrice)
+                    .isStockExcept(isStockExcept)
+                    .isTradingHalt(isTradingHalt)
+                    .isInvestmentAlert(isInvestmentAlert)
+                    .isManagement(isManagement)
                     .build())
             .build();
         

--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -138,7 +138,7 @@ public class BuyThenService {
         Boolean isTradingHalt = stockPrice.getTradingHalt();
         Boolean isInvestmentAlert = stockPrice.getInvestmentAlert();
         Boolean isManagement = stockPrice.getManagement();
-        Boolean isStockExcept = isTradingHalt | isInvestmentAlert | isManagement;
+        Boolean isStockExcept = isTradingHalt || isInvestmentAlert || isManagement;
         isExceptCase = isStockExcept;
 
         // 과거 주가

--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -49,7 +49,7 @@ import com.stocking.modules.buyornot.repo.EvaluateBuySell.BuySell;
 import com.stocking.modules.buythen.CalcAllRes.CalculatedResult;
 import com.stocking.modules.buythen.CalcHistRes.CalculationHist;
 import com.stocking.modules.buythen.CalculatedRes.CalculatedValue;
-import com.stocking.modules.buythen.CalculatedRes.ExceptionCase;
+import com.stocking.modules.buythen.CalculatedRes.ExceptCase;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.CurrentValue;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.IndustryValue;
 import com.stocking.modules.buythen.CurrentKospiIndustryRes.KospiValue;
@@ -132,13 +132,13 @@ public class BuyThenService {
         InvestDate investDate = buyThenForm.getInvestDate();    // 투자 날짜
         BigDecimal investPrice = buyThenForm.getInvestPrice();  // 투자금
 
-        Boolean isExceptionCase = Boolean.FALSE;                // 예외 케이스 여부
+        Boolean isExceptCase = Boolean.FALSE;                // 예외 케이스 여부
 
         // 과거 주가
         List<InvestDate> investDates = new ArrayList<InvestDate>(EnumSet.allOf(InvestDate.class));
         int investDateIndex = investDates.indexOf(investDate);
         InvestDate newInvestDate = investDate;
-        Boolean isDateExceptionCase = Boolean.FALSE;
+        Boolean isDateExceptCase = Boolean.FALSE;
 
         Optional<BigDecimal> oldStockPrice = Optional.empty();
         for (int i=investDateIndex;i>=0;i--) {
@@ -152,14 +152,12 @@ public class BuyThenService {
                 case YEAR10 -> stockPrice.getPriceY10();
                 default -> throw new IllegalArgumentException("Unexpected value: " + newInvestDate);
             });
-            System.out.println("test");
-            System.out.println(oldStockPrice);
             if (oldStockPrice.isPresent()) {
                 break;
             }
             newInvestDate = investDates.get(i);
-            isDateExceptionCase = Boolean.TRUE;
-            isExceptionCase = Boolean.TRUE;
+            isDateExceptCase = Boolean.TRUE;
+            isExceptCase = Boolean.TRUE;
         }
         if (!oldStockPrice.isPresent()) {
             throw new Exception(
@@ -182,13 +180,12 @@ public class BuyThenService {
 
         // 금액값 예외 확인
         BigDecimal newInvestPrice = investPrice;
-        Boolean isPriceException = Boolean.FALSE;
+        Boolean isPriceExcept = Boolean.FALSE;
         if (oldStockPrice.get().compareTo(investPrice) > 0) {
             newInvestPrice = oldStockPrice.get();
-            isExceptionCase = Boolean.TRUE;
-            isPriceException = Boolean.TRUE;
+            isExceptCase = Boolean.TRUE;
+            isPriceExcept = Boolean.TRUE;
         }
-
         // 상승률 계산
         RealTimeStock realTimeStock = stockUtils.getStockInfo(code);
 
@@ -263,13 +260,13 @@ public class BuyThenService {
                     .salaryYear(salaryYear)
                     .salaryMonth(salaryMonth)
                     .build())
-            .exceptionCase(
-                ExceptionCase.builder()
-                    .isExceptionCase(isExceptionCase)
-                    .isDateException(isDateExceptionCase)
+            .exceptCase(
+                ExceptCase.builder()
+                    .isExceptCase(isExceptCase)
+                    .isDateExcept(isDateExceptCase)
                     .oldInvestDate(investDate)
                     .newInvestDate(newInvestDate)
-                    .isPriceException(isPriceException)
+                    .isPriceExcept(isPriceExcept)
                     .oldInvestPrice(investPrice)
                     .newInvestPrice(newInvestPrice)
                     .build())

--- a/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
+++ b/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
@@ -24,7 +24,7 @@ public class CalculatedRes {
     @ApiModelProperty(notes = "계산 결과", required=false, position=5)
     private CalculatedValue calculatedValue;
     @ApiModelProperty(notes = "예외 케이스", required=false, position=6)
-    private ExceptionCase exceptionCase;
+    private ExceptCase exceptCase;
     
     @Data
     @AllArgsConstructor
@@ -53,7 +53,7 @@ public class CalculatedRes {
     @Data
     @AllArgsConstructor
     @Builder
-    public static class ExceptionCase {
+    public static class ExceptCase {
         @ApiModelProperty(notes = "예외 케이스 여부", required=false, position=1)
         private Boolean isExceptCase;
 

--- a/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
+++ b/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
@@ -55,25 +55,29 @@ public class CalculatedRes {
     @Builder
     public static class ExceptionCase {
         @ApiModelProperty(notes = "예외 케이스 여부", required=false, position=1)
-        private Boolean isExceptionCase;
+        private Boolean isExceptCase;
 
         @ApiModelProperty(notes = "기간값 예외 케이스 여부", required=false, position=2)
-        private Boolean isDateException;
+        private Boolean isDateExcept;
         @ApiModelProperty(notes = "기존 투자 날짜", required=false, position=3)
         private InvestDate oldInvestDate;
         @ApiModelProperty(notes = "새 투자 날짜", required=false, position=4)
         private InvestDate newInvestDate;
 
         @ApiModelProperty(notes = "금액값 예외 케이스 여부", required=false, position=5)
-        private Boolean isPriceException;
+        private Boolean isPriceExcept;
         @ApiModelProperty(notes = "기존 금액값", required=false, position=6)
         private BigDecimal oldInvestPrice;
         @ApiModelProperty(notes = "새 금액값", required=false, position=7)
         private BigDecimal newInvestPrice;
 
         @ApiModelProperty(notes = "종목 예외 케이스 여부", required=false, position=8)
-        private Boolean isStockException;
-        @ApiModelProperty(notes = "종목 예외 경고 메시지", required=false, position=9)
-        private String stockWarnMsg;
+        private Boolean isStockExcept;
+        @ApiModelProperty(notes = "거래중지 여부", required=false, position=9)
+        private Boolean isTradingHalt;
+        @ApiModelProperty(notes = "투자경고 여부", required=false, position=10)
+        private Boolean isInvestmentAlert;
+        @ApiModelProperty(notes = "관리종목(상장폐지 우려) 여부", required=false, position=11)
+        private Boolean isManagement;
     }
 }


### PR DESCRIPTION
## #13

## PR 설명
- 거래 중지, 투자 경고, 관리 종목 주식에 대한 예외 케이스 처리 기능 추가

## 변경된 내용
- 계산기 응답부에 위 3가지 + 종목 예외케이스 여부를 Boolean 형으로 응답하게 하는 기능 추가

## 추가적인 정보
- 네이버 금융 투자자 보호 페이지에서 정보 가져옴
