### PR TITLE
[Feature/buythen] 삼전, SK하이닉스, 카카오 주식 수 가져오는 기능 추가

### DIFF
--- a/src/main/java/com/stocking/modules/buythen/BuyThenService.java
+++ b/src/main/java/com/stocking/modules/buythen/BuyThenService.java
@@ -191,9 +191,17 @@ public class BuyThenService {
         BigDecimal currentPrice = realTimeStock.getCurrentPrice(); // 현재가 - 실시간정보 호출
         String lastTradeTime = realTimeStock.getLastTradeTime();
 
-        BigDecimal holdingStock = newInvestPrice.divide(oldStockPrice.get(), MathContext.DECIMAL32);     // 내가 산 주식 개수
-        BigDecimal yieldPercent = currentPrice.subtract(oldStockPrice.get()).divide(oldStockPrice.get(), MathContext.DECIMAL32).multiply(new BigDecimal(100));  // (현재가-이전종가)/이전종가 * 100
-        BigDecimal yieldPrice = newInvestPrice.add(newInvestPrice.multiply(yieldPercent).divide(new BigDecimal(100)));  // 수익금 = 투자금 + (투자금*수익률*100)
+        BigDecimal holdingStock = newInvestPrice  // 내가 산 주식 개수
+                .divide(oldStockPrice.get(), MathContext.DECIMAL32)
+                .setScale(2, RoundingMode.HALF_UP);
+        BigDecimal yieldPercent = currentPrice.subtract(oldStockPrice.get()) // (현재가-이전종가)/이전종가 * 100
+                .divide(oldStockPrice.get(), MathContext.DECIMAL32)
+                .multiply(new BigDecimal(100))
+                .setScale(2, RoundingMode.HALF_UP);
+        BigDecimal yieldPrice = newInvestPrice.add(
+                newInvestPrice
+                .multiply(yieldPercent)
+                .divide(new BigDecimal(100)));  // 수익금 = 투자금 + (투자금*수익률*100)
 
 
         // 연봉/월급, 삼성/sk/kakao 주식 계산, 종가일자
@@ -275,16 +283,15 @@ public class BuyThenService {
                 break;
             default : throw new IllegalArgumentException("Unexpected value: " + newInvestDate);
         }
-
         samsungStock = newInvestPrice
                 .divide(samsungStock, MathContext.DECIMAL32)
-                .setScale(1, RoundingMode.HALF_UP);
+                .setScale(2, RoundingMode.HALF_UP);
         skStock = newInvestPrice
                 .divide(skStock, MathContext.DECIMAL32)
-                .setScale(1, RoundingMode.HALF_UP);
+                .setScale(2, RoundingMode.HALF_UP);
         kakaoStock = newInvestPrice
                 .divide(kakaoStock, MathContext.DECIMAL32)
-                .setScale(1, RoundingMode.HALF_UP);
+                .setScale(2, RoundingMode.HALF_UP);
 
         // 계산이력 저장
         calcHistRepository.save(

--- a/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
+++ b/src/main/java/com/stocking/modules/buythen/CalculatedRes.java
@@ -44,10 +44,16 @@ public class CalculatedRes {
         private BigDecimal oldPrice;
         @ApiModelProperty(notes = "보유 주식 수", required=false, position=7)
         private BigDecimal holdingStock;
-        @ApiModelProperty(notes = "연봉", required=false, position=8)
+        @ApiModelProperty(notes = "연봉(수익률 상승일 때)", required=false, position=8)
         private BigDecimal salaryYear;
-        @ApiModelProperty(notes = "월급", required=false, position=9)
+        @ApiModelProperty(notes = "월급(수익률 상승일 때)", required=false, position=9)
         private BigDecimal salaryMonth;
+        @ApiModelProperty(notes = "삼성 주식 수(수익률 하락일 때)", required = false, position = 10)
+        private BigDecimal samsungStock;
+        @ApiModelProperty(notes = "SK 하이닉스 주식 수(수익률 하락일 때)", required = false, position = 11)
+        private BigDecimal skStock;
+        @ApiModelProperty(notes = "카카오 주식 수(수익률 하락일 때)", required = false, position = 12)
+        private BigDecimal kakaoStock;
     }
 
     @Data


### PR DESCRIPTION
## #13

## PR 설명
- 수익률이 하락세일 때 보이는 '다른 종목 보유 주식 수'에 해당하는 데이터를 추가로 응답하게 수정했습니다.
- 다른 종목은 삼성전자, SK하이닉스, 카카오입니다.

## 변경된 내용
아래 이미지와 같이 삼전, sk, 카카오 응답부가 추가됐습니다.
<img width="231" alt="스크린샷 2021-06-05 오후 4 25 26" src="https://user-images.githubusercontent.com/46209590/120883867-a5520f80-c61a-11eb-9fd9-f92c893f76d0.png">
